### PR TITLE
Handle HTTP client errors 

### DIFF
--- a/lib/gcm.js
+++ b/lib/gcm.js
@@ -93,6 +93,9 @@ GCM.prototype.send = function(packet, cb) {
             res.on('end', respond);
             res.on('close', respond);
         });
+        request.on('error', function(error) {
+            self.emit('sent', error, null);
+        });
         request.end(postData);
     });
 };


### PR DESCRIPTION
Test: turn off your network connection and try to send any GCM notification.
