### PR TITLE
Handle concurrency properly (fix #7)

### DIFF
--- a/lib/gcm.js
+++ b/lib/gcm.js
@@ -3,6 +3,7 @@ var https = require('https');
 var querystring = require('querystring');
 var emitter = require('events').EventEmitter;
 var retry = require('retry');
+var noop = function() {};
 
 function GCM(apiKey) {
     if (apiKey) {
@@ -25,7 +26,6 @@ exports.GCM = GCM;
 
 GCM.prototype.send = function(packet, cb) {
     var self = this;
-    if (cb) this.once('sent', cb);
 
     var operation = retry.operation();
 
@@ -58,6 +58,8 @@ GCM.prototype.send = function(packet, cb) {
                     }
                 }
                 if (!operation.retry('TemporaryUnavailable')) {
+                    cb(operation.mainError(), null);
+                    cb = noop;
                     self.emit('sent', operation.mainError(), null);
                 }
                 // Ignore all subsequent events for this request
@@ -84,6 +86,8 @@ GCM.prototype.send = function(packet, cb) {
                 }
 
                 // Success, return message id (without id=)
+                cb(error, id);
+                cb = noop;
                 self.emit('sent', error, id);
             }
 
@@ -94,6 +98,8 @@ GCM.prototype.send = function(packet, cb) {
             res.on('close', respond);
         });
         request.on('error', function(error) {
+            cb(error, null);
+            cb = noop;
             self.emit('sent', error, null);
         });
         request.end(postData);

--- a/lib/gcm.js
+++ b/lib/gcm.js
@@ -12,9 +12,9 @@ function GCM(apiKey) {
         throw Error('No apiKey is given.');
     }
     this.gcmOptions = {
-        host: 'android.googleapis.com',
+        host: 'fcm.googleapis.com',
         port: 443,
-        path: '/gcm/send',
+        path: '/fcm/send',
         method: 'POST',
         headers: {}
     };


### PR DESCRIPTION
When using the same instance of GCM to `.send()` in parallel, you'll only get one message id (or one error), since the function was relying on a single EventEmitter for all calls.

This PR makes the library works in parallel.

To maintain backward compatibility, I kept the `.emit()` behavior, even though the library itself isn't using it anymore.